### PR TITLE
A prototype of much faster langfuse ingestion

### DIFF
--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -17,10 +17,10 @@ import { DB } from ".";
 
 const prismaClientSingleton = () => {
   return new PrismaClient({
-    log:
-      env.NODE_ENV === "development"
-        ? ["query", "error", "warn"]
-        : ["error", "warn"],
+    log: ["error", "warn"],
+      // env.NODE_ENV === "development"
+      //   ? ["query", "error", "warn"]
+      //   : ["error", "warn"],
   });
 };
 

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -179,7 +179,7 @@ export const handleBatch = async (
   req: NextApiRequest,
   authCheck: AuthHeaderVerificationResult,
 ) => {
-  console.log("handling ingestion event", JSON.stringify(events, null, 2));
+  console.log(`handling ingestion event with ${events.length} events`);
 
   if (!authCheck.validKey) throw new UnauthorizedError(authCheck.error);
 
@@ -254,8 +254,7 @@ const handleSingleEvent = async (
   apiScope: ApiAccessScope,
 ) => {
   console.log(
-    `handling single event ${event.id}`,
-    JSON.stringify(event, null, 2),
+    `handling single event ${event.id} ${event.type}`
   );
 
   const cleanedEvent = ingestionEvent.parse(cleanEvent(event));

--- a/web/src/server/api/services/EventProcessor.ts
+++ b/web/src/server/api/services/EventProcessor.ts
@@ -97,7 +97,7 @@ export async function findModel(p: {
   return foundModels[0] ?? null;
 }
 
-type ObservationEvent =
+export type ObservationEvent =
   | z.infer<typeof legacyObservationCreateEvent>
   | z.infer<typeof legacyObservationUpdateEvent>
   | z.infer<typeof eventCreateEvent>

--- a/web/src/server/api/services/EventProcessor.ts
+++ b/web/src/server/api/services/EventProcessor.ts
@@ -169,6 +169,11 @@ export class ObservationProcessor implements EventProcessor {
           })
         : undefined;
 
+    if (!this.event.body.traceId && !existingObservation) {
+      console.log("I am going to create an empty trace");
+      console.log(this.event.body);
+    }
+
     const traceId =
       !this.event.body.traceId && !existingObservation
         ? // Create trace if no traceid


### PR DESCRIPTION
## What does this PR do?

Langfuse ingestion is quite slow, because the ingestion code path makes read/write SQL queries for each observation that's received.

This PR attempts a different version of the ingestion code path that reads and writes to the DB in batches.

The performance improvement is significant.

Before:
POST request with 260 events completes in 5s

Running on 100 gleason docs:
```
Processed 100 documents in 0m4s
POST http://localhost:6007/api/public/ingestion took 3.7955631249933504s with 1007.714KB 307 events
POST http://localhost:6007/api/public/ingestion took 8.681478124985006s with 1446.973KB 314 events
POST http://localhost:6007/api/public/ingestion took 9.812697500048671s with 825.628KB 335 events
Langfuse flush took 0m19s
```


After:

POST request with 260 events completes in 873ms

Running on 100 gleason docs:
```
POST http://localhost:6007/api/public/ingestion took 1.0489602909656242s with 920.933KB 264 events
POST http://localhost:6007/api/public/ingestion took 0.7444410839816555s with 1653.679KB 400 events
POST http://localhost:6007/api/public/ingestion took 0.5013136669876985s with 705.703KB 292 events
Processed 100 documents in 0m4s
Langfuse flush took 0m0s
```

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

